### PR TITLE
Fix: Disable green activity icons

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -462,6 +462,14 @@ export default definePlugin({
     },
 
     patches: [
+         {
+            // Disable the green icons to bypass breaking patches
+            find: "activity_status_cleanup",
+            replacement: {
+                match: /activityStatusCleanupEnabled:!0/,
+                replace: "activityStatusCleanupEnabled:!1",
+            }
+        },
         {
             // Patch activity icons
             find: "\"activity-status-web",


### PR DESCRIPTION
Taken from Equicord/Equicord@e89e2491f8c20558247585981777c5aa855fb783, not mine. 

This may not be the desired solution, but the *actual* code that the regex matches hasn't changed so Discord changed something else with the green indicators. 

Fixes #13 