### PR TITLE
Bug & QOL Fixes

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -382,8 +382,11 @@ export default definePlugin({
                                     onMouseLeave={onMouseLeave}
                                     onClick={() => {
                                         const index = activities.indexOf(currentActivity!);
-                                        if (index - 1 >= 0)
+                                        if (index - 1 >= 0) {
                                             setCurrentActivity(activities[index - 1]);
+                                        } else {
+                                            setCurrentActivity(activities[activities.length - 1]);
+                                        }
                                     }}
                                 >
                                     <Caret
@@ -410,8 +413,11 @@ export default definePlugin({
                                     onMouseLeave={onMouseLeave}
                                     onClick={() => {
                                         const index = activities.indexOf(currentActivity!);
-                                        if (index + 1 < activities.length)
+                                        if (index + 1 < activities.length) {
                                             setCurrentActivity(activities[index + 1]);
+                                        } else {
+                                            setCurrentActivity(activities[0]);
+                                        }
                                     }}
                                 >
                                     <Caret

--- a/index.tsx
+++ b/index.tsx
@@ -469,7 +469,7 @@ export default definePlugin({
             // Show all activities in the user popout/sidebar
             find: '"UserProfilePopoutBody"',
             replacement: {
-                match: /(?<=user:(\i).*?\i\.id\)\}\)\),(\i).*?)\(0,\i\.jsx\).{0,100}\i\.activity\}\)/,
+                match: /(?<=(\i)\.id\)\}\)\),(\i).*?)\(0,\i\.jsx\).{0,100}\i\.activity\}\)/,
                 replace: ",$self.showAllActivitiesComponent({ activity: $2, user: $1 })"
             },
             predicate: () => settings.store.userPopout

--- a/index.tsx
+++ b/index.tsx
@@ -469,7 +469,7 @@ export default definePlugin({
             // Show all activities in the user popout/sidebar
             find: '"UserProfilePopoutBody"',
             replacement: {
-                match: /(?<=(\i)\.id\)\}\)\),(\i).*?)\(0,\i\.jsx\).{0,100}\i\.activity\}\)/,
+                match: /(?<=(\i)\.id\)\}\)\),(\i).*?)\(0,.{0,100}\i\.activity\}\)/,
                 replace: ",$self.showAllActivitiesComponent({ activity: $2, user: $1 })"
             },
             predicate: () => settings.store.userPopout

--- a/index.tsx
+++ b/index.tsx
@@ -245,10 +245,10 @@ export default definePlugin({
 
     settings,
 
-    patchActivityList: ({ activities, user }: { activities: Activity[], user: User; }): JSX.Element | null => {
+    patchActivityList: ({ activities, user, hideTooltip }: { activities: Activity[], user: User, hideTooltip: boolean; }): JSX.Element | null => {
         const icons: ActivityListIcon[] = [];
 
-        if (user.bot) return null;
+        if (user.bot || hideTooltip) return null;
 
         const applicationIcons = getApplicationIcons(activities);
         if (applicationIcons.length) {


### PR DESCRIPTION
Before:
![Screenshot 2025-03-25 122347](https://github.com/user-attachments/assets/a382f3a0-cb9b-4f49-98ac-9e6099af70bb)

After:
![Screenshot 2025-03-25 122357](https://github.com/user-attachments/assets/ecc89a0c-472a-4984-894d-5b54ddf269c0)

Optimized the popout patch slightly as grabbing the user from a func before activities was better than running .*? again

Carousel left & right arrow now will cycle fully through every activity if its all the way left/right it goes to the end/beginning of length and keeps going