### PR TITLE
fix: use PresenceStore for member list activity icons

### DIFF
--- a/patch-helpers/activityList.tsx
+++ b/patch-helpers/activityList.tsx
@@ -20,7 +20,13 @@ import { cl, getApplicationIcons } from "../utils";
 const DefaultActivityIcon = findComponentByCodeLazy("M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V5a3 3 0 0 0-3-3H5Zm6.81 7c-.54 0-1 .26-1.23.61A1 1 0 0 1 8.92 8.5 3.49 3.49 0 0 1 11.82 7c1.81 0 3.43 1.38 3.43 3.25 0 1.45-.98 2.61-2.27 3.06a1 1 0 0 1-1.96.37l-.19-1a1 1 0 0 1 .98-1.18c.87 0 1.44-.63 1.44-1.25S12.68 9 11.81 9ZM13 16a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm7-10.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM18.5 20a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM7 18.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z");
 
 export function patchActivityList({ activities: rawActivities, user, hideTooltip }: ActivityListProps): JSX.Element | null {
-    const fullActivities = PresenceStore.getActivities(user.id) ?? rawActivities;
+    const fullActivities = React.useSyncExternalStore(
+        cb => {
+            PresenceStore.addChangeListener(cb);
+            return () => PresenceStore.removeChangeListener(cb);
+        },
+        () => PresenceStore.getActivities(user.id) ?? rawActivities
+    );
     const icons: ActivityListIcon[] = [];
 
     if (user.bot || settings.store.hideTooltip && hideTooltip) return null;

--- a/patch-helpers/activityList.tsx
+++ b/patch-helpers/activityList.tsx
@@ -7,7 +7,7 @@
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Activity } from "@vencord/discord-types";
 import { findComponentByCodeLazy } from "@webpack";
-import { React, Tooltip } from "@webpack/common";
+import { PresenceStore, React, Tooltip } from "@webpack/common";
 import { JSX } from "react";
 
 import { ActivityTooltip } from "../components/ActivityTooltip";
@@ -20,11 +20,12 @@ import { cl, getApplicationIcons } from "../utils";
 const DefaultActivityIcon = findComponentByCodeLazy("M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V5a3 3 0 0 0-3-3H5Zm6.81 7c-.54 0-1 .26-1.23.61A1 1 0 0 1 8.92 8.5 3.49 3.49 0 0 1 11.82 7c1.81 0 3.43 1.38 3.43 3.25 0 1.45-.98 2.61-2.27 3.06a1 1 0 0 1-1.96.37l-.19-1a1 1 0 0 1 .98-1.18c.87 0 1.44-.63 1.44-1.25S12.68 9 11.81 9ZM13 16a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm7-10.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM18.5 20a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM7 18.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z");
 
 export function patchActivityList({ activities: rawActivities, user, hideTooltip }: ActivityListProps): JSX.Element | null {
+    const fullActivities = PresenceStore.getActivities(user.id) ?? rawActivities;
     const icons: ActivityListIcon[] = [];
 
     if (user.bot || settings.store.hideTooltip && hideTooltip) return null;
 
-    const activities = rawActivities.filter((a): a is Activity => a != null);
+    const activities = fullActivities.filter((a): a is Activity => a != null);
     const applicationIcons = getApplicationIcons(activities);
     if (applicationIcons.length) {
         const compareImageSource = (a: ApplicationIcon, b: ApplicationIcon) => {


### PR DESCRIPTION
Discord sends stripped-down activity data to the member list component, while other components like friend list receive the full payload..
This causes activity icons to not render for some users in the member list.
Fix by querying PresenceStore.getActivities(user.id) which always contains the complete activity data